### PR TITLE
FIX: re-queue failing requests due to connection forcibly closed

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -9,52 +9,30 @@
  *
  */
 
-const axios = require('./axios');
 const Buttress = require('./buttressjs');
 const Helpers = require('./helpers');
+const Schema = require('./schema.js');
 
-const _getSchema = () => {
-  return axios.getInstance().get(`${Buttress.coreURL}/app/schema`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+const App = new Schema('app', Buttress.options, true);
+
+/**
+ * @param {object} [options={}] options
+ * @return {promise} - response
+ */
+App.getSchema = function(options = {}) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  return this._request('get', 'schema', options);
 };
 
-const _getAll = (buttressAuthToken) => {
-  const token = buttressAuthToken ? buttressAuthToken : Buttress.authToken;
-  return axios.getInstance().get(`${Buttress.coreURL}/app`, {params: {token: token}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+/**
+* @param {object} schema
+* @param {object} [options={}] options
+ * @return {promise} - response
+ */
+App.updateSchema = function(schema, options = {}) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  if (schema) options.data = schema;
+  return this._request('put', 'schema', options);
 };
 
-const _load = (buttressId) => {
-  return axios.getInstance().get(`${Buttress.coreURL}/app/${buttressId}`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-const _save = (details) => {
-  return axios.getInstance().post(`${Buttress.coreURL}/app`, details, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-const _update = (buttressId, details) => {
-  return axios.getInstance().put(`${Buttress.coreURL}/app/${buttressId}`, details, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-const _remove = (buttressId) => {
-  return axios.getInstance().delete(`${Buttress.coreURL}/app/${buttressId}`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-module.exports = {
-  getSchema: _getSchema,
-  getAll: _getAll,
-  get: _load,
-  save: _save,
-  update: _update,
-  remove: _remove,
-};
+module.exports = App;

--- a/lib/app.js
+++ b/lib/app.js
@@ -25,7 +25,7 @@ App.getSchema = function(options = {}) {
 };
 
 /**
-* @param {object} schema
+* @param {array} schema
 * @param {object} [options={}] options
  * @return {promise} - response
  */
@@ -33,6 +33,17 @@ App.updateSchema = function(schema, options = {}) {
   options = Helpers.checkOptions(options, Buttress.authToken);
   if (schema) options.data = schema;
   return this._request('put', 'schema', options);
+};
+
+/**
+* @param {object} roles
+* @param {object} [options={}] options
+ * @return {promise} - response
+ */
+App.updateRoles = function(roles, options = {}) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  if (roles) options.data = roles;
+  return this._request('put', 'roles', options);
 };
 
 module.exports = App;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -8,61 +8,50 @@
  * @author Chris Bates-Keegan
  *
  */
-const axios = require('./axios');
+
 const Buttress = require('./buttressjs');
 const Helpers = require('./helpers');
+const Schema = require('./schema.js');
+
+const User = require('./user.js');
+
+const Auth = new Schema('auth', Buttress.options, true);
 
 /**
  * @param {Object} user - user details
  * @param {Object} auth - auth details
  * @param {Object} options - request options
  * @return {Promise} - resolves to the serialized User object
- * @private
  */
-const _findOrCreateUser = (user, auth, options) => {
-  options = Helpers.checkOptions(options);
-
-  return axios.getInstance().get(`${Buttress.coreURL}/user/${user.app}/${user.id}`, {params: {token: Buttress.authToken}})
-    .then((response) => {
-      if (response.data === false) {
-        return axios.getInstance().post(`${Buttress.coreURL}/user`, {user: user, auth: auth}, {params: {token: Buttress.authToken}});
-      }
-
-      return response;
-    })
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+Auth.findOrCreateUser = function(user, auth, options) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  return User.findUser(user.app, user.id)
+    .then((data) => (data === false) ? User.save({user: user, auth: auth}) : data);
 };
 
 /**
  * @param {Object} userId - user id
  * @param {Object} token - token details
+ * @param {Object} options - request options
  * @return {Promise} - resolves to the serialized Token object
- * @private
  */
-const _createToken = (userId, token) => {
-  return axios.getInstance().post(`${Buttress.coreURL}/user/${userId}/token`, token, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+Auth.createToken = function(userId, token, options) {
+  return User.createToken(userId, token, options);
 };
 
 /**
  * @param {Object} userId - user details
  * @param {Object} appAuth - app auth details
  * @return {Promise} - resolves to the serialized User object
- * @private
  */
-const _addAuthToUser = (userId, appAuth) => {
-  return axios.getInstance().put(`${Buttress.coreURL}/user/${userId}/auth`, {params: {token: Buttress.authToken}, data: {auth: appAuth}})
+Auth.addAuthToUser = function(userId, appAuth) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  if (appAuth) options.data = appAuth;
+  return this._request('put', `${userId}/auth`, options)
     .then((response) => Object.assign(response.data, {
       buttressId: userId,
       buttressAuthToken: response.data.authToken,
-    }))
-    .catch((err) => Helpers.handleError(err));
+    }));
 };
 
-module.exports = {
-  findOrCreateUser: _findOrCreateUser,
-  addAuthToUser: _addAuthToUser,
-  createToken: _createToken,
-};
+module.exports = Auth;

--- a/lib/buttressjs.js
+++ b/lib/buttressjs.js
@@ -17,7 +17,6 @@ const URL = require('url').URL;
 const Helpers = require('./helpers');
 const Schema = require(`./schema.js`);
 const axios = require('./axios');
-const helpers = require('./helpers');
 
 /**
  * @class Buttress
@@ -126,8 +125,7 @@ class Buttress {
         return Promise.resolve();
       }
 
-      return axios.getInstance().put(`${this.coreURL}/app/roles`, this.options.roles, {params: {token: this.authToken}})
-        .then((response) => response.data);
+      return this.App.updateRoles(this.options.roles);
     };
 
     return Promise.all([updateSchema(), updateRoles()])

--- a/lib/buttressjs.js
+++ b/lib/buttressjs.js
@@ -113,7 +113,7 @@ class Buttress {
         return Promise.resolve();
       }
 
-      return axios.getInstance().put(`${this.coreURL}/app/schema`, this.options.schema, {params: {token: this.authToken}})
+      return this.App.updateSchema(this.options.schema)
         .then(() => this.App.getSchema())
         .then((schema) => {
           this.options.compiledSchema = schema;

--- a/lib/buttressjs.js
+++ b/lib/buttressjs.js
@@ -128,8 +128,7 @@ class Buttress {
       return this.App.updateRoles(this.options.roles);
     };
 
-    return Promise.all([updateSchema(), updateRoles()])
-      .catch((err) => Helpers.handleError(err));
+    return Promise.all([updateSchema(), updateRoles()]);
   }
 
   /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,17 @@ const ObjectId = require('mongodb').ObjectId;
 
 const Errors = {
   NotYetInitiated: class extends Error {constructor(message) {super(message); this.name = 'ButtressNotYetInitiated';}},
-  SchemaNotFound: class extends Error {constructor(message) {super(message); this.name = 'SchemaNotFound';}}
+  SchemaNotFound: class extends Error {constructor(message) {super(message); this.name = 'SchemaNotFound';}},
+  ResponseError: class extends Error {
+    constructor(response) {
+      super();
+      this.name = 'ResponseError';
+      this.code = this.statusCode = response.status;
+      this.statusMessage = response.statusText;
+      this.message = (response.data.message) ? response.data.message : response.statusText;
+    }
+  },
+  RequestError: class extends Error {constructor(err) {super(err.message); this.code = err.code; this.name = 'RequestError';}},
 };
 
 /**
@@ -288,16 +298,12 @@ const _checkOptions = (options, defaultToken) => {
   return options;
 };
 
-const handleError = (err) => {
-  if (err.response) {
-    throw {
-      statusCode: err.response.status,
-      statusMessage: err.response.statusText,
-      message: err.response.data.message,
-    };
-  }
-
-  console.error(err);
+const sleep = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+const backOff = (attempt) => {
+  const delay = Math.pow(2, attempt) * 200;
+  return sleep(delay + (delay * 0.2 * Math.random()));
 };
 
 module.exports = {
@@ -305,5 +311,6 @@ module.exports = {
   Schema,
   Errors,
   checkOptions: _checkOptions,
-  handleError,
+  sleep,
+  backOff,
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -32,6 +32,16 @@ class Schema {
   }
 
   /**
+   * Schema Constants
+   */
+  static get Constants() {
+    return {
+      MAX_RETRIES: 10,
+      RETRY_METHODS: ['get', 'options', 'head'],
+    };
+  }
+
+  /**
    * @return {object} schema
    */
   getSchema() {
@@ -71,9 +81,10 @@ class Schema {
    * @param {string} type
    * @param {string} path
    * @param {object} options
+   * @param {int} attempt
    * @return {promise}
    */
-  _request(type, path, options) {
+  _request(type, path, options, attempt = 0) {
     if (!this._route) {
       throw new Error(`Unable to make request to Buttress due to unknown schema ${this.collection}`);
     }
@@ -100,9 +111,33 @@ class Schema {
       };
     }
 
+    attempt++;
+
     return axios.getInstance().request(options)
       .then((response) => response.data)
-      .catch((err) => Helpers.handleError(err));
+      .catch((err) => {
+        let error = err;
+
+        if (err.response) {
+          error = new Helpers.Errors.ResponseError(err.response);
+        } else if (err.request) {
+          error = new Helpers.Errors.RequestError(err);
+        }
+
+        // Handle error type and retry if necessary
+        if (error instanceof Helpers.Errors.RequestError &&
+          Boolean(error.code) &&
+          error.code !== 'ECONNABORTED' &&
+          Schema.Constants.RETRY_METHODS.includes(type)
+        ) {
+          if (attempt >= Schema.Constants.MAX_RETRIES) throw error;
+
+          return Helpers.backOff(attempt)
+            .then(() => this._request(type, path, options, attempt));
+        }
+
+        throw error;
+      });
   }
 
   /**

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -20,15 +20,18 @@ class Schema {
    * Instance of Schema
    * @param {object} collection
    * @param {object} ButtressOptions
+   * @param {boolean} [core=false] - core schema
    */
-  constructor(collection, ButtressOptions) {
+  constructor(collection, ButtressOptions, core = false) {
     this.collection = collection;
     this._ButtressOptions = ButtressOptions;
 
-    this._route = null;
+    this._route = (core) ? collection : null;
     this._schema = null;
 
-    this.getSchema();
+    this._endpoint = (core) ? this._ButtressOptions.urls.core : this._ButtressOptions.urls.app;
+
+    if (!core) this.getSchema();
   }
 
   /**
@@ -91,7 +94,7 @@ class Schema {
 
     options.method = type;
 
-    let url = `${this._ButtressOptions.urls.app}/${this._route}`;
+    let url = `${this._endpoint}/${this._route}`;
     if (path) {
       url = `${url}/${path}`;
     }

--- a/lib/token.js
+++ b/lib/token.js
@@ -8,39 +8,38 @@
  * @author Chris Bates-Keegan
  *
  */
-const axios = require('./axios');
+
 const Buttress = require('./buttressjs');
 const Helpers = require('./helpers');
+const Schema = require('./schema.js');
+
+const Token = new Schema('token', Buttress.options, true);
+
+Token.AuthLevel = {
+  NONE: 0,
+  USER: 1,
+  ADMIN: 2,
+  SUPER: 3,
+};
 
 /**
  * @param {object} options
  * @return {promise}
  */
-function _rmAllUserTokens(options) {
+Token.removeAllUserTokens = function(options) {
   options = Helpers.checkOptions(options, Buttress.authToken);
-
-  return axios.getInstance().delete(`${Buttress.coreURL}/token/user`, options)
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-}
+  return this._request('delete', `user`, options);
+};
 
 /**
  * @param {object} details
+ * @param {object} options
  * @return {promise}
  */
-function _updateRole(details) {
-  return axios.getInstance().put(`${Buttress.coreURL}/token/roles`, details, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+Token.updateRole = function(details, options) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  if (details) options.data = details;
+  return this._request('put', `roles`, options);
 };
 
-module.exports = {
-  removeAllUserTokens: _rmAllUserTokens,
-  updateRole: _updateRole,
-  AuthLevel: {
-    NONE: 0,
-    USER: 1,
-    ADMIN: 2,
-    SUPER: 3,
-  },
-};
+module.exports = Token;

--- a/lib/user.js
+++ b/lib/user.js
@@ -7,74 +7,33 @@
  *
  */
 
-const axios = require('./axios');
 const Buttress = require('./buttressjs');
+const Helpers = require('./helpers');
+const Schema = require('./schema.js');
 
-/**
- * @return {promise}
- */
-function _getAll() {
-  return axios.getInstance().get(`${Buttress.coreURL}/user`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-/**
- * @return {promise}
- */
-function _rmAll() {
-  return axios.getInstance().delete(`${Buttress.coreURL}/user`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
+const User = new Schema('user', Buttress.options, true);
 
 /**
  * @param {string} appName
  * @param {string} appUserId
+ * @param {Object} [options={}] options - request options
  * @return {promise}
  */
-function _findUser(appName, appUserId) {
-  return axios.getInstance().get(`${Buttress.coreURL}/user/${appName}/${appUserId}`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+User.findUser = function(appName, appUserId, options = {}) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  return this._request('get', `${appName}/${appUserId}`, options);
 };
 
 /**
- * @param {string} buttressUserId
- * @return {promise}
+ * @param {Object} userId - user id
+ * @param {Object} token - token details
+ * @param {Object} options - request options
+ * @return {Promise} - resolves to the serialized Token object
  */
-function _loadUser(buttressUserId) {
-  return axios.getInstance().get(`${Buttress.coreURL}/user/${buttressUserId}`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
+User.createToken = function(userId, token, options) {
+  options = Helpers.checkOptions(options, Buttress.authToken);
+  if (token) options.data = token;
+  return this._request('post', `${userId}/token`, options);
 };
 
-/**
- * @param {string} buttressId
- * @param {object} details
- * @return {promise}
- */
-function _update(buttressId, details) {
-  return axios.getInstance().put(`${Buttress.coreURL}/user/${buttressId}`, details, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-/**
- * @param {string} buttressUserId
- * @return {promise}
- */
-function _removeUser(buttressUserId) {
-  return axios.getInstance().delete(`${Buttress.coreURL}/user/${buttressUserId}`, {params: {token: Buttress.authToken}})
-    .then((response) => response.data)
-    .catch((err) => Helpers.handleError(err));
-};
-
-module.exports = {
-  getAll: _getAll,
-  removeAll: _rmAll,
-  remove: _removeUser,
-  get: _loadUser,
-  findUser: _findUser,
-  update: _update,
-};
+module.exports = User;


### PR DESCRIPTION
Refactored API's will return a Error object if possible. Added ResponseError & RequestError. A RequestError will be recalled up to 10 times if the request is in retry methods array.

I've also refactored the core API's to use it's own instance of Schema to make calls and go through the same error flow.

@Mahmoud-Abousereaa Can you check this over in your env before I merge?